### PR TITLE
Plottable child data

### DIFF
--- a/app.py
+++ b/app.py
@@ -265,6 +265,10 @@ def plottable_child_data():
     else:
         return "Request body should be application/json", 400
 
+spec.components.schema("plottableChildData", schema=PlottableChildDataResponseSchema)
+with app.test_request_context():
+    spec.path(view=uk_who_plottable_child_data)
+
 @app.route("/uk-who/spreadsheet", methods=["POST"])
 def ukwho_spreadsheet():
     """

--- a/app.py
+++ b/app.py
@@ -248,15 +248,13 @@ def plottable_child_data():
     if request.is_json:
         req = request.get_json()
         results = req["results"]
-        print(type(results))
-        unique_child = req["unique_child"]
         # born preterm flag to pass to charts
-        born_preterm = (results[0]["birth_data"]["gestation_weeks"]
-                        != 0 and results[0]["birth_data"]["gestation_weeks"] < 37)
+        # born_preterm = (results[0]["birth_data"]["gestation_weeks"]
+        #                 != 0 and results[0]["birth_data"]["gestation_weeks"] < 37)
 
         # data are serial data points for a single child
         # Prepare data from plotting
-        child_data = controllers.create_data_plots(results)
+        child_data = controllers.create_plottable_child_data(results)
         # Retrieve sex of child to select correct centile charts
         sex = results[0]["birth_data"]["sex"]
         

--- a/app.py
+++ b/app.py
@@ -14,7 +14,8 @@ from flask_cors import CORS
 import blueprints
 import controllers
 from schemas import (SingleCalculationResponseSchema, MultipleCalculationsResponseSchema,
-                     ReferencesResponseSchema, FictionalChildResponseSchema, ChartDataResponseSchema)
+                     ReferencesResponseSchema, FictionalChildResponseSchema, ChartDataResponseSchema,
+                     PlottableChildDataResponseSchema)
 
 
 #######################
@@ -222,7 +223,7 @@ with app.test_request_context():
     spec.path(view=uk_who_chart_data)
 
 @app.route("/uk-who/plottable-child-data", methods=["POST"])
-def plottable_child_data():
+def uk_who_plottable_child_data():
     """
     Child growth data in plottable format API route.
     ---

--- a/app.py
+++ b/app.py
@@ -221,6 +221,51 @@ spec.components.schema("chartData", schema=ChartDataResponseSchema)
 with app.test_request_context():
     spec.path(view=uk_who_chart_data)
 
+@app.route("/uk-who/plottable-child-data", methods=["POST"])
+def plottable_child_data():
+    """
+    Child growth data in plottable format API route.
+    ---
+    post:
+      summary: |
+        Child growth data in plottable format
+        Requires results data paramaters from a call to the calculation endpoint.
+        Returns child measurement data in a plottable format (x and y parameters), 
+        with centiles and ages for labels.
+
+      requestBody:
+        content:
+          application/json:
+            schema: ChartDataRequestParameters
+
+      responses:
+        200:
+          description: "Child growth data in plottable format (x and y parameters, centile and age labels)"
+          content:
+            application/json:
+              schema: ChartDataResponseSchema
+    """
+    if request.is_json:
+        req = request.get_json()
+        results = req["results"]
+        print(type(results))
+        unique_child = req["unique_child"]
+        # born preterm flag to pass to charts
+        born_preterm = (results[0]["birth_data"]["gestation_weeks"]
+                        != 0 and results[0]["birth_data"]["gestation_weeks"] < 37)
+
+        # data are serial data points for a single child
+        # Prepare data from plotting
+        child_data = controllers.create_data_plots(results)
+        # Retrieve sex of child to select correct centile charts
+        sex = results[0]["birth_data"]["sex"]
+        
+        return jsonify({
+            "sex": sex,
+            "child_data": child_data,
+        })
+    else:
+        return "Request body should be application/json", 400
 
 @app.route("/uk-who/spreadsheet", methods=["POST"])
 def ukwho_spreadsheet():

--- a/controllers/__init__.py
+++ b/controllers/__init__.py
@@ -4,3 +4,4 @@ from .references import references
 from .temp_test_functions import test_sds_tim_term_heights, tim_tests_preterm
 from .upload import prepare_data_as_array_of_measurement_objects, import_csv_file
 from .fictional_children import generate_fictional_children_data
+from .plottable_child import create_plottable_child_data

--- a/controllers/plottable_child.py
+++ b/controllers/plottable_child.py
@@ -12,6 +12,8 @@ def create_plottable_child_data(child_results_array):
             chronological_data_point = {
                 "x": child_result["measurement_dates"]["chronological_decimal_age"], 
                 "y": child_result["child_observation_value"]["measurement_value"],
+                "centile_band": child_result["measurement_calculated_values"]["centile_band"],
+                "centile_value": child_result["measurement_calculated_values"]["centile"],
                 "label": "chronological_age",
                 "calendar_age": child_result["measurement_dates"]["chronological_calendar_age"],
                 "corrected_gestational_weeks": child_result["corrected_gestational_age"]["corrected_gestational_weeks"],
@@ -20,6 +22,8 @@ def create_plottable_child_data(child_results_array):
             corrected_data_point = {
                 "x": child_result["measurement_dates"]["corrected_decimal_age"], 
                 "y": child_result["child_observation_value"]["measurement_value"],
+                "centile_band": child_result["measurement_calculated_values"]["centile_band"],
+                "centile_value": child_result["measurement_calculated_values"]["centile"],
                 "label": "corrected_age",
                 "calendar_age": child_result["measurement_dates"]["corrected_calendar_age"],
                 "corrected_gestational_weeks": child_result["corrected_gestational_age"]["corrected_gestational_weeks"],
@@ -110,6 +114,8 @@ def sds_value_for_centile_value(centile: float):
             {
                 x: 9.415, `this is the age of the child at date of measurement in decimal years
                 y: 120 `this is the observation value - the units will be added in the client
+                "centile_band": 'You childs height is between the 75th and 91st centiles' `a text advice string for labelling,
+                "centile_value": 86 `centile number value - reported but not used: the project board do not like exact centile numbers,
                 "label": "corrected_age", `this is a flag to differentiate the two ages for the same observation_value
                 "calendar_age": "9 years and 4 months" `this is the calendar age for labelling
                 "corrected_gestational_weeks": 23 `the corrected gestational age if relevant for labelling

--- a/controllers/plottable_child.py
+++ b/controllers/plottable_child.py
@@ -1,0 +1,131 @@
+def create_plottable_child_data(child_results_array):
+    child_height_data = []
+    child_weight_data = []
+    child_bmi_data = []
+    child_ofc_data = []
+    child_height_sds_data = []
+    child_weight_sds_data = []
+    child_bmi_sds_data = []
+    child_ofc_sds_data = []
+    for count, child_result in enumerate(child_results_array):
+        if(child_result):
+            chronological_data_point = {
+                "x": child_result["measurement_dates"]["chronological_decimal_age"], 
+                "y": child_result["child_observation_value"]["measurement_value"],
+                "label": "chronological_age",
+                "calendar_age": child_result["measurement_dates"]["chronological_calendar_age"],
+                "corrected_gestational_weeks": child_result["corrected_gestational_age"]["corrected_gestational_weeks"],
+                "corrected_gestational_days": child_result["corrected_gestational_age"]["corrected_gestational_days"]
+            }
+            corrected_data_point = {
+                "x": child_result["measurement_dates"]["corrected_decimal_age"], 
+                "y": child_result["child_observation_value"]["measurement_value"],
+                "label": "corrected_age",
+                "calendar_age": child_result["measurement_dates"]["corrected_calendar_age"],
+                "corrected_gestational_weeks": child_result["corrected_gestational_age"]["corrected_gestational_weeks"],
+                "corrected_gestational_days": child_result["corrected_gestational_age"]["corrected_gestational_days"]
+            }
+            chronological_sds_data_point = {
+                "x": child_result["measurement_dates"]["chronological_decimal_age"], 
+                "y": child_result["measurement_calculated_values"]["sds"],
+                "label": "chronological_age",
+                "calendar_age": child_result["measurement_dates"]["chronological_calendar_age"],
+                "corrected_gestational_weeks": child_result["corrected_gestational_age"]["corrected_gestational_weeks"],
+                "corrected_gestational_days": child_result["corrected_gestational_age"]["corrected_gestational_days"]
+            }
+            corrected_sds_data_point = {
+                "x": child_result["measurement_dates"]["corrected_decimal_age"], 
+                "y": child_result["measurement_calculated_values"]["sds"],
+                "label": "corrected_age",
+                "calendar_age": child_result["measurement_dates"]["chronological_calendar_age"],
+                "corrected_gestational_weeks": child_result["corrected_gestational_age"]["corrected_gestational_weeks"],
+                "corrected_gestational_days": child_result["corrected_gestational_age"]["corrected_gestational_days"]
+            }
+            if(child_result["child_observation_value"]["measurement_method"] == "height"):
+                child_height_data.append(corrected_data_point)
+                child_height_data.append(chronological_data_point)
+                child_height_sds_data.append(corrected_sds_data_point)
+                child_height_sds_data.append(chronological_sds_data_point)
+            elif(child_result["child_observation_value"]["measurement_method"] == "weight"):
+                child_weight_data.append(corrected_data_point)
+                child_weight_data.append(chronological_data_point)
+                child_weight_sds_data.append(corrected_sds_data_point)
+                child_weight_sds_data.append(chronological_sds_data_point)
+            elif(child_result["child_observation_value"]["measurement_method"] == "bmi"):
+                child_bmi_data.append(corrected_data_point)
+                child_bmi_data.append(chronological_data_point)
+                child_bmi_sds_data.append(corrected_sds_data_point)
+                child_bmi_sds_data.append(chronological_sds_data_point)
+            elif(child_result["child_observation_value"]["measurement_method"] == "ofc"):
+                child_ofc_data.append(corrected_data_point)
+                child_ofc_data.append(chronological_data_point)
+                child_ofc_sds_data.append(corrected_sds_data_point)
+                child_ofc_sds_data.append(chronological_sds_data_point)
+
+        
+    result = {
+        "heights": child_height_data,
+        "height_sds": child_height_sds_data,
+        "weights": child_weight_data,
+        "weight_sds": child_weight_sds_data,
+        "bmis": child_bmi_data,
+        "bmi_sds": child_bmi_sds_data,
+        "ofcs": child_ofc_data,
+        "ofc_sds": child_ofc_sds_data
+    }
+
+    return result
+
+
+
+def sds_value_for_centile_value(centile: float):
+
+    if centile == 0.4:
+        return -2.0 - (2/3)
+    elif centile == 2:
+        return -2.0
+    elif centile == 9:
+        return -1 - (1/3)
+    elif centile == 25:
+        return 0 - (2/3)
+    elif centile == 50:
+        return 0
+    elif centile == 75:
+        return 2/3
+    elif centile == 91:
+        return 1 + (1/3)
+    elif centile == 98:
+        return 2.0
+    elif centile == 99.6:
+        return 2 + (2/3)
+    else:
+        #error
+        raise LookupError("SDS could not be calculated from Centile supplied")
+
+    """
+    Return object structure
+
+    [
+        heights: [
+            {
+                x: 9.415, `this is the age of the child at date of measurement in decimal years
+                y: 120 `this is the observation value - the units will be added in the client
+                "label": "corrected_age", `this is a flag to differentiate the two ages for the same observation_value
+                "calendar_age": "9 years and 4 months" `this is the calendar age for labelling
+                "corrected_gestational_weeks": 23 `the corrected gestational age if relevant for labelling
+                "corrected_gestational_days": 1 `the corrected gestational age if relevant for labelling
+            }
+        ],
+        height_sds: [
+                x: 9.415, `this is the age of the child at date of measurement in decimal years
+                y: 1.3 `this is the SDS value for SDS charts
+                "label": "corrected_age", `this is a flag to differentiate the two ages for the same observation_value
+                "calendar_age": "9 years and 4 months" `this is the calendar age for labelling
+                "corrected_gestational_weeks": 23 `the corrected gestational age if relevant for labelling
+                "corrected_gestational_days": 1 `the corrected gestational age if relevant for labelling
+        ],
+        .... and so on for the other measurement_methods
+        
+    ]
+
+    """

--- a/controllers/plottable_child.py
+++ b/controllers/plottable_child.py
@@ -63,7 +63,7 @@ def create_plottable_child_data(child_results_array):
                 child_height_sds_data.append(measurement_sds_data_points)
             elif(child_result["child_observation_value"]["measurement_method"] == "weight"):
                 child_weight_data.append(measurement_data_points)
-                child_weight_sds_data..append(measurement_sds_data_points)
+                child_weight_sds_data.append(measurement_sds_data_points)
             elif(child_result["child_observation_value"]["measurement_method"] == "bmi"):
                 child_bmi_data.append(measurement_data_points)
                 child_bmi_sds_data.append(measurement_sds_data_points)

--- a/controllers/plottable_child.py
+++ b/controllers/plottable_child.py
@@ -9,6 +9,15 @@ def create_plottable_child_data(child_results_array):
     child_ofc_sds_data = []
     for count, child_result in enumerate(child_results_array):
         if(child_result):
+
+            ## create 4 plottable return objects for each measurement: one for each corrected and chronological age
+            ## per measurement and per SDS score
+            ## These measurement pairs and SDS pairs are stored in a 2 2-value arrays, so that each measurement/SDS
+            ## can be plotted as a series in the charts.
+            ## If there are multiple values to plot, the return array will be a string of arrays of paired values,
+            ## which allows them to be plotted as pairs: this is because corrected and chronological values should be
+            ## linked by a line, the chronological value denotes as a dot, the corrected value as a cross.
+
             chronological_data_point = {
                 "x": child_result["measurement_dates"]["chronological_decimal_age"], 
                 "y": child_result["child_observation_value"]["measurement_value"],
@@ -45,28 +54,23 @@ def create_plottable_child_data(child_results_array):
                 "corrected_gestation_weeks": child_result["measurement_dates"]["corrected_gestational_age"]["corrected_gestation_weeks"],
                 "corrected_gestation_days": child_result["measurement_dates"]["corrected_gestational_age"]["corrected_gestation_days"]
             }
-            if(child_result["child_observation_value"]["measurement_method"] == "height"):
-                child_height_data.append(corrected_data_point)
-                child_height_data.append(chronological_data_point)
-                child_height_sds_data.append(corrected_sds_data_point)
-                child_height_sds_data.append(chronological_sds_data_point)
-            elif(child_result["child_observation_value"]["measurement_method"] == "weight"):
-                child_weight_data.append(corrected_data_point)
-                child_weight_data.append(chronological_data_point)
-                child_weight_sds_data.append(corrected_sds_data_point)
-                child_weight_sds_data.append(chronological_sds_data_point)
-            elif(child_result["child_observation_value"]["measurement_method"] == "bmi"):
-                child_bmi_data.append(corrected_data_point)
-                child_bmi_data.append(chronological_data_point)
-                child_bmi_sds_data.append(corrected_sds_data_point)
-                child_bmi_sds_data.append(chronological_sds_data_point)
-            elif(child_result["child_observation_value"]["measurement_method"] == "ofc"):
-                child_ofc_data.append(corrected_data_point)
-                child_ofc_data.append(chronological_data_point)
-                child_ofc_sds_data.append(corrected_sds_data_point)
-                child_ofc_sds_data.append(chronological_sds_data_point)
 
-        
+            measurement_data_points=[corrected_data_point, chronological_data_point]
+            measurement_sds_data_points=[corrected_sds_data_point, chronological_sds_data_point]
+
+            if(child_result["child_observation_value"]["measurement_method"] == "height"):
+                child_height_data.append(measurement_data_points)
+                child_height_sds_data.append(measurement_sds_data_points)
+            elif(child_result["child_observation_value"]["measurement_method"] == "weight"):
+                child_weight_data.append(measurement_data_points)
+                child_weight_sds_data..append(measurement_sds_data_points)
+            elif(child_result["child_observation_value"]["measurement_method"] == "bmi"):
+                child_bmi_data.append(measurement_data_points)
+                child_bmi_sds_data.append(measurement_sds_data_points)
+            elif(child_result["child_observation_value"]["measurement_method"] == "ofc"):
+                child_ofc_data.append(measurement_data_points)
+                child_ofc_sds_data.append(measurement_sds_data_points)
+
     result = {
         "heights": child_height_data,
         "height_sds": child_height_sds_data,

--- a/controllers/plottable_child.py
+++ b/controllers/plottable_child.py
@@ -16,8 +16,8 @@ def create_plottable_child_data(child_results_array):
                 "centile_value": child_result["measurement_calculated_values"]["centile"],
                 "label": "chronological_age",
                 "calendar_age": child_result["measurement_dates"]["chronological_calendar_age"],
-                "corrected_gestational_weeks": child_result["corrected_gestational_age"]["corrected_gestational_weeks"],
-                "corrected_gestational_days": child_result["corrected_gestational_age"]["corrected_gestational_days"]
+                "corrected_gestation_weeks": child_result["measurement_dates"]["corrected_gestational_age"]["corrected_gestation_weeks"],
+                "corrected_gestation_days": child_result["measurement_dates"]["corrected_gestational_age"]["corrected_gestation_days"]
             }
             corrected_data_point = {
                 "x": child_result["measurement_dates"]["corrected_decimal_age"], 
@@ -26,24 +26,24 @@ def create_plottable_child_data(child_results_array):
                 "centile_value": child_result["measurement_calculated_values"]["centile"],
                 "label": "corrected_age",
                 "calendar_age": child_result["measurement_dates"]["corrected_calendar_age"],
-                "corrected_gestational_weeks": child_result["corrected_gestational_age"]["corrected_gestational_weeks"],
-                "corrected_gestational_days": child_result["corrected_gestational_age"]["corrected_gestational_days"]
+                "corrected_gestation_weeks": child_result["measurement_dates"]["corrected_gestational_age"]["corrected_gestation_weeks"],
+                "corrected_gestation_days": child_result["measurement_dates"]["corrected_gestational_age"]["corrected_gestation_days"]
             }
             chronological_sds_data_point = {
                 "x": child_result["measurement_dates"]["chronological_decimal_age"], 
                 "y": child_result["measurement_calculated_values"]["sds"],
                 "label": "chronological_age",
                 "calendar_age": child_result["measurement_dates"]["chronological_calendar_age"],
-                "corrected_gestational_weeks": child_result["corrected_gestational_age"]["corrected_gestational_weeks"],
-                "corrected_gestational_days": child_result["corrected_gestational_age"]["corrected_gestational_days"]
+                "corrected_gestation_weeks": child_result["measurement_dates"]["corrected_gestational_age"]["corrected_gestation_weeks"],
+                "corrected_gestation_days": child_result["measurement_dates"]["corrected_gestational_age"]["corrected_gestation_days"]
             }
             corrected_sds_data_point = {
                 "x": child_result["measurement_dates"]["corrected_decimal_age"], 
                 "y": child_result["measurement_calculated_values"]["sds"],
                 "label": "corrected_age",
                 "calendar_age": child_result["measurement_dates"]["chronological_calendar_age"],
-                "corrected_gestational_weeks": child_result["corrected_gestational_age"]["corrected_gestational_weeks"],
-                "corrected_gestational_days": child_result["corrected_gestational_age"]["corrected_gestational_days"]
+                "corrected_gestation_weeks": child_result["measurement_dates"]["corrected_gestational_age"]["corrected_gestation_weeks"],
+                "corrected_gestation_days": child_result["measurement_dates"]["corrected_gestational_age"]["corrected_gestation_days"]
             }
             if(child_result["child_observation_value"]["measurement_method"] == "height"):
                 child_height_data.append(corrected_data_point)

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -297,6 +297,13 @@ components:
         response:
           type: string
       type: object
+    plottableChildData:
+      properties:
+        child_data:
+          type: string
+        sex:
+          type: string
+      type: object
     references:
       properties:
         references:
@@ -375,6 +382,30 @@ paths:
         Requires results data paramaters from a call to the calculation endpoint.
 
         Returns geometry data for constructing the lines of a traditional growth chart.
+
+        '
+  /uk-who/plottable-child-data:
+    post:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ChartDataRequestParameters'
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/chartData'
+          description: Child growth data in plottable format (x and y parameters,
+            centile and age labels)
+      summary: 'Child growth data in plottable format
+
+        Requires results data paramaters from a call to the calculation endpoint.
+
+        Returns child measurement data in a plottable format (x and y parameters),
+
+        with centiles and ages for labels.
 
         '
   /utilities/references:

--- a/rcpchgrowth.code-workspace
+++ b/rcpchgrowth.code-workspace
@@ -8,6 +8,9 @@
 		},
 		{
 			"path": "../../../react/digital-growth-charts-react"
+		},
+		{
+			"path": "../../../react/component-libraries/digital-growth-charts-react-chart-component"
 		}
 	],
 	"settings": {

--- a/schemas/__init__.py
+++ b/schemas/__init__.py
@@ -1,4 +1,5 @@
 from .chart_data_schemas import ChartDataRequestParameters, ChartDataResponseSchema
+from .plottable_child_data_schemas import PlottableChildDataRequestParameters, PlottableChildDataResponseSchema
 from .fictional_child_schemas import FictionalChildRequestParameters, FictionalChildResponseSchema
 from .multiple_calculations_schemas import MultipleCalculationsRequestParameters, MultipleCalculationsResponseSchema
 from .measurement_schemas import MeasurementResponseSchema

--- a/schemas/plottable_child_data_schemas.py
+++ b/schemas/plottable_child_data_schemas.py
@@ -1,0 +1,10 @@
+from marshmallow import Schema, fields
+
+
+class PlottableChildDataRequestParameters(Schema):
+    results = fields.String()
+
+
+class PlottableChildDataResponseSchema(Schema):
+    sex = fields.String()
+    child_data = fields.String()


### PR DESCRIPTION
This includes a new endpoint called plottable-child-data. The documentation and openapi spec should be correct but do please check. This endpoint receives the Measurement object from the client and returns it optimised for plotting. x: age y: observation_value as key value pairs. Strings are returned also for use in tool tips in the charting package. Each measurement is returned as an array of two objects - one for corrected age, one for chronological. This allows the charting package to see them as a series and plot them together. This array of pairs is itself returned in an array to allow for return of multiple values in future. All previous endpoints are unchanged so the unstable branch clients that depend on receiving the whole chart will not be affected.
To test this you will need to use the react client in the plottable-child-branch which is now refactored to use the new react charting package, now hosted also at github. 