### PR TITLE
Datetime format fix

### DIFF
--- a/apispec_generation.py
+++ b/apispec_generation.py
@@ -25,9 +25,9 @@ def generate(app, api_commit_hash, api_semantic_version):
             license={"name": "GNU Affero General Public License",
                      "url": "https://www.gnu.org/licenses/agpl-3.0.en.html"}),
         plugins=[MarshmallowPlugin(), FlaskPlugin()],
-        servers=[{"url": 'https://api.rcpch.ac.uk/',
+        servers=[{"url": 'https://api.rcpch.ac.uk',
                   "description": 'RCPCH Production API Gateway (subscription keys required)'},
-                 {"url": 'https://localhost:5000/',
+                 {"url": 'https://localhost:5000',
                   "description": 'Your local development API'}],
     )
 

--- a/app.py
+++ b/app.py
@@ -18,7 +18,7 @@ from rcpchgrowth.rcpchgrowth.chart_functions import create_chart
 
 
 ### API VERSION AND COMMIT HASH ###
-API_SEMANTIC_VERSION = "1.0.12"  # this is manually set
+API_SEMANTIC_VERSION = "2.1.0"  # this is manually set
 
 # Read saved version info from **saved** JSON APIspec
 # (Because Git may not exist in Live and may not be able to get current commit hash)

--- a/blueprints/trisomy_21_blueprint.py
+++ b/blueprints/trisomy_21_blueprint.py
@@ -36,8 +36,8 @@ def trisomy_21_calculation():
           application/json:
             schema: CalculationRequestParameters
             example:
-                birth_date: "2020-04-12"
-                observation_date: "2020-06-12"
+                birth_date: "2020-04-12T12:00:00"
+                observation_date: "2020-06-12T12:00:00"
                 observation_value: 60
                 measurement_method: "height"
                 sex: male
@@ -74,8 +74,8 @@ def trisomy_21_calculation():
 
         calculation = Measurement(
             sex=req["sex"],
-            birth_date=datetime.strptime(req["birth_date"], "%Y-%m-%d"),
-            observation_date=datetime.strptime(req["observation_date"],"%Y-%m-%d"),
+            birth_date=datetime.strptime(req["birth_date"], "%Y-%m-%dT%H:%M:%S"),
+            observation_date=datetime.strptime(req["observation_date"],"%Y-%m-%dT%H:%M:%S"),
             measurement_method=str(req["measurement_method"]),
             observation_value=float(req["observation_value"]),
             gestation_weeks=req["gestation_weeks"],

--- a/blueprints/turner_blueprint.py
+++ b/blueprints/turner_blueprint.py
@@ -35,8 +35,8 @@ def turner_calculation():
           application/json:
             schema: CalculationRequestParameters
             example:
-                birth_date: "2020-04-12"
-                observation_date: "2020-06-12"
+                birth_date: "2020-04-12T12:00:00"
+                observation_date: "2020-06-12T12:00:00"
                 observation_value: 60
                 measurement_method: "height"
                 sex: male
@@ -73,8 +73,8 @@ def turner_calculation():
 
         calculation = Measurement(
             sex=req["sex"],
-            birth_date=datetime.strptime(req["birth_date"], "%Y-%m-%d"),
-            observation_date=datetime.strptime(req["observation_date"],"%Y-%m-%d"),
+            birth_date=datetime.strptime(req["birth_date"], "%Y-%m-%dT%H:%M:%S"),
+            observation_date=datetime.strptime(req["observation_date"],"%Y-%m-%dT%H:%M:%S"),
             measurement_method=str(req["measurement_method"]),
             observation_value=float(req["observation_value"]),
             gestation_weeks=req["gestation_weeks"],

--- a/blueprints/uk_who_blueprint.py
+++ b/blueprints/uk_who_blueprint.py
@@ -41,8 +41,8 @@ def uk_who_calculation():
           application/json:
             schema: CalculationRequestParameters
             example:
-                birth_date: "2020-04-12"
-                observation_date: "2020-06-12"
+                birth_date: "2020-04-12T12:00:00"
+                observation_date: "2020-06-12T12:00:00"
                 observation_value: 60
                 measurement_method: "height"
                 sex: male
@@ -79,8 +79,8 @@ def uk_who_calculation():
 
         calculation = Measurement(
             sex=req["sex"],
-            birth_date=datetime.strptime(req["birth_date"], "%Y-%m-%d"),
-            observation_date=datetime.strptime(req["observation_date"],"%Y-%m-%d"),
+            birth_date=datetime.strptime(req["birth_date"], "%Y-%m-%dT%H:%M:%S"),
+            observation_date=datetime.strptime(req["observation_date"],"%Y-%m-%dT%H:%M:%S"),
             measurement_method=str(req["measurement_method"]),
             observation_value=float(req["observation_value"]),
             gestation_weeks=req["gestation_weeks"],

--- a/blueprints/uk_who_blueprint.py
+++ b/blueprints/uk_who_blueprint.py
@@ -41,8 +41,8 @@ def uk_who_calculation():
           application/json:
             schema: CalculationRequestParameters
             example:
-                birth_date: "2020-04-12T12:00:00"
-                observation_date: "2020-06-12T12:00:00"
+                birth_date: "2020-04-12T0:00:00"
+                observation_date: "2020-06-12T00:00:00"
                 observation_value: 60
                 measurement_method: "height"
                 sex: male
@@ -77,16 +77,23 @@ def uk_who_calculation():
             pprint(err.messages)
             return json.dumps(err.messages), 422
 
-        calculation = Measurement(
-            sex=req["sex"],
-            birth_date=datetime.strptime(req["birth_date"], "%Y-%m-%dT%H:%M:%S"),
-            observation_date=datetime.strptime(req["observation_date"],"%Y-%m-%dT%H:%M:%S"),
-            measurement_method=str(req["measurement_method"]),
-            observation_value=float(req["observation_value"]),
-            gestation_weeks=req["gestation_weeks"],
-            gestation_days=req["gestation_days"],
-            reference=UK_WHO
-        ).measurement
+        # datetimes will reject anything after a '.' because of odd example formatting in Azure APIM dev portal
+        try:
+            calculation = Measurement(
+                sex=req["sex"],
+                birth_date=datetime.strptime(
+                    req["birth_date"].split('.', 1)[0], "%Y-%m-%dT%H:%M:%S"),
+                observation_date=datetime.strptime(
+                    req["observation_date"].split('.', 1)[0], "%Y-%m-%dT%H:%M:%S"),
+                measurement_method=str(req["measurement_method"]),
+                observation_value=float(req["observation_value"]),
+                gestation_weeks=req["gestation_weeks"],
+                gestation_days=req["gestation_days"],
+                reference=UK_WHO
+            ).measurement
+        except ValueError as err:
+            pprint(err.args)
+            return json.dumps(err.args), 422
 
         return jsonify(calculation)
     else:
@@ -94,7 +101,6 @@ def uk_who_calculation():
 
 
 @uk_who.route("/chart-coordinates", methods=["POST"])
-
 def uk_who_chart_coordinates():
     """
     Chart data.
@@ -116,29 +122,31 @@ def uk_who_chart_coordinates():
               schema: ChartDataResponseSchema
     """
     if request.is_json:
-      req = request.get_json()
-      print(req)
-      values = {
-        "sex":req["sex"],
-        'measurement_method':req["measurement_method"]
-      }
-    
-      try:
-        ChartDataRequestParameters().load(values)
-      except ValidationError as err:
-        pprint(err.messages)
-        return json.dumps(err.messages), 422
+        req = request.get_json()
+        print(req)
+        values = {
+            "sex": req["sex"],
+            'measurement_method': req["measurement_method"]
+        }
 
-      try:
-        chart_data = create_chart(UK_WHO, measurement_method=req["measurement_method"], sex=req["sex"], centile_selection=COLE_TWO_THIRDS_SDS_NINE_CENTILES)
-      except Exception as err:
-        print(err)
+        try:
+            ChartDataRequestParameters().load(values)
+        except ValidationError as err:
+            pprint(err.messages)
+            return json.dumps(err.messages), 422
 
-      return jsonify({
-          "centile_data": chart_data
-      })
+        try:
+            chart_data = create_chart(
+                UK_WHO, measurement_method=req["measurement_method"], sex=req["sex"], centile_selection=COLE_TWO_THIRDS_SDS_NINE_CENTILES)
+        except Exception as err:
+            print(err)
+
+        return jsonify({
+            "centile_data": chart_data
+        })
     else:
         return "Request body mimetype should be application/json", 400
+
 
 """
     Return object structure

--- a/openapi.json
+++ b/openapi.json
@@ -29,8 +29,8 @@
             "CalculationRequestParameters": {
                 "properties": {
                     "birth_date": {
-                        "description": "Date of birth of the patient in YYYY-MM-DD ISO8601 format.",
-                        "format": "date",
+                        "description": "Date of birth of the patient in `YYYY-MM-DDTHH:MM:SS` FHIR format.",
+                        "format": "date-time",
                         "type": "string"
                     },
                     "gestation_days": {
@@ -54,8 +54,8 @@
                         "type": "string"
                     },
                     "observation_date": {
-                        "description": "The date that the measurement was taken, in YYYY-MM-DD ISO8601 format.",
-                        "format": "date",
+                        "description": "The date that the measurement was taken, in `YYYY-MM-DDTHH:MM:SS` FHIR format.",
+                        "format": "date-time",
                         "type": "string"
                     },
                     "observation_value": {
@@ -313,11 +313,11 @@
                     "content": {
                         "application/json": {
                             "example": {
-                                "birth_date": "2020-04-12",
+                                "birth_date": "2020-04-12T12:00:00",
                                 "gestation_days": 4,
                                 "gestation_weeks": 40,
                                 "measurement_method": "height",
-                                "observation_date": "2020-06-12",
+                                "observation_date": "2020-06-12T12:00:00",
                                 "observation_value": 60,
                                 "sex": "male"
                             },
@@ -349,11 +349,11 @@
                     "content": {
                         "application/json": {
                             "example": {
-                                "birth_date": "2020-04-12",
+                                "birth_date": "2020-04-12T12:00:00",
                                 "gestation_days": 4,
                                 "gestation_weeks": 40,
                                 "measurement_method": "height",
-                                "observation_date": "2020-06-12",
+                                "observation_date": "2020-06-12T12:00:00",
                                 "observation_value": 60,
                                 "sex": "male"
                             },
@@ -385,11 +385,11 @@
                     "content": {
                         "application/json": {
                             "example": {
-                                "birth_date": "2020-04-12",
+                                "birth_date": "2020-04-12T12:00:00",
                                 "gestation_days": 4,
                                 "gestation_weeks": 40,
                                 "measurement_method": "height",
-                                "observation_date": "2020-06-12",
+                                "observation_date": "2020-06-12T12:00:00",
                                 "observation_value": 60,
                                 "sex": "male"
                             },
@@ -482,11 +482,11 @@
     "servers": [
         {
             "description": "RCPCH Production API Gateway (subscription keys required)",
-            "url": "https://api.rcpch.ac.uk/"
+            "url": "https://api.rcpch.ac.uk"
         },
         {
             "description": "Your local development API",
-            "url": "https://localhost:5000/"
+            "url": "https://localhost:5000"
         }
     ]
 }

--- a/openapi.json
+++ b/openapi.json
@@ -284,7 +284,7 @@
             "url": "https://www.gnu.org/licenses/agpl-3.0.en.html"
         },
         "title": "RCPCH Digital Growth Charts API",
-        "version": "v1.0.12 (commit_hash: 5c4545abc150a7b4f75336a74612b68b0b8c6ec9)"
+        "version": "v1.0.12 (commit_hash: c614c31663c9259f3d743ed523ef10827ac7e9df)"
     },
     "openapi": "3.0.2",
     "paths": {
@@ -385,11 +385,11 @@
                     "content": {
                         "application/json": {
                             "example": {
-                                "birth_date": "2020-04-12T12:00:00",
+                                "birth_date": "2020-04-12T0:00:00",
                                 "gestation_days": 4,
                                 "gestation_weeks": 40,
                                 "measurement_method": "height",
-                                "observation_date": "2020-06-12T12:00:00",
+                                "observation_date": "2020-06-12T00:00:00",
                                 "observation_value": 60,
                                 "sex": "male"
                             },

--- a/openapi.yml
+++ b/openapi.yml
@@ -20,8 +20,9 @@ components:
     CalculationRequestParameters:
       properties:
         birth_date:
-          description: Date of birth of the patient in YYYY-MM-DD ISO8601 format.
-          format: date
+          description: Date of birth of the patient in `YYYY-MM-DDTHH:MM:SS` FHIR
+            format.
+          format: date-time
           type: string
         gestation_days:
           description: The number of additional days _beyond the completed weeks of
@@ -52,9 +53,9 @@ components:
           - ofc
           type: string
         observation_date:
-          description: The date that the measurement was taken, in YYYY-MM-DD ISO8601
-            format.
-          format: date
+          description: The date that the measurement was taken, in `YYYY-MM-DDTHH:MM:SS`
+            FHIR format.
+          format: date-time
           type: string
         observation_value:
           description: The value of the measurement supplied. Used in conjunction
@@ -234,11 +235,11 @@ paths:
         content:
           application/json:
             example:
-              birth_date: '2020-04-12'
+              birth_date: '2020-04-12T12:00:00'
               gestation_days: 4
               gestation_weeks: 40
               measurement_method: height
-              observation_date: '2020-06-12'
+              observation_date: '2020-06-12T12:00:00'
               observation_value: 60
               sex: male
             schema:
@@ -331,11 +332,11 @@ paths:
         content:
           application/json:
             example:
-              birth_date: '2020-04-12'
+              birth_date: '2020-04-12T12:00:00'
               gestation_days: 4
               gestation_weeks: 40
               measurement_method: height
-              observation_date: '2020-06-12'
+              observation_date: '2020-06-12T12:00:00'
               observation_value: 60
               sex: male
             schema:
@@ -391,11 +392,11 @@ paths:
         content:
           application/json:
             example:
-              birth_date: '2020-04-12'
+              birth_date: '2020-04-12T12:00:00'
               gestation_days: 4
               gestation_weeks: 40
               measurement_method: height
-              observation_date: '2020-06-12'
+              observation_date: '2020-06-12T12:00:00'
               observation_value: 60
               sex: male
             schema:
@@ -411,6 +412,6 @@ paths:
       summary: Centile and SDS Calculation route.
 servers:
 - description: RCPCH Production API Gateway (subscription keys required)
-  url: https://api.rcpch.ac.uk/
+  url: https://api.rcpch.ac.uk
 - description: Your local development API
-  url: https://localhost:5000/
+  url: https://localhost:5000

--- a/openapi.yml
+++ b/openapi.yml
@@ -215,7 +215,7 @@ info:
     name: GNU Affero General Public License
     url: https://www.gnu.org/licenses/agpl-3.0.en.html
   title: RCPCH Digital Growth Charts API
-  version: 'v1.0.12 (commit_hash: 5c4545abc150a7b4f75336a74612b68b0b8c6ec9)'
+  version: 'v1.0.12 (commit_hash: c614c31663c9259f3d743ed523ef10827ac7e9df)'
 openapi: 3.0.2
 paths:
   /uk-who/calculation:
@@ -235,11 +235,11 @@ paths:
         content:
           application/json:
             example:
-              birth_date: '2020-04-12T12:00:00'
+              birth_date: '2020-04-12T0:00:00'
               gestation_days: 4
               gestation_weeks: 40
               measurement_method: height
-              observation_date: '2020-06-12T12:00:00'
+              observation_date: '2020-06-12T00:00:00'
               observation_value: 60
               sex: male
             schema:

--- a/rcpchgrowth/rcpchgrowth/schemas/measurement_class_schema.py
+++ b/rcpchgrowth/rcpchgrowth/schemas/measurement_class_schema.py
@@ -6,10 +6,10 @@ class MeasurementClassSchema(Schema):
         required=True,
         enum=['male', 'female'],
         description="The sex of the patient, as a string value which can either be `male` or `female`. Abbreviations or alternatives are not accepted")
-    birth_date = fields.Date(
+    birth_date = fields.DateTime(
         required=True,
         description="Date of birth of the patient, as a Python Date object.")
-    observation_date = fields.Date(
+    observation_date = fields.DateTime(
         required=True,
         description="The date that the measurement was taken, as a Python Date object.")
     measurement_method = fields.String(

--- a/rcpchgrowth/setup.py
+++ b/rcpchgrowth/setup.py
@@ -9,7 +9,7 @@ with open(path.join(here, 'README.md'), encoding='utf-8') as f:
 
 setup(
     name='rcpchgrowth',
-    version='2.0.0',  # Required
+    version='2.1.0',  # Required
     description='SDS and Centile calculations for UK Growth Data',
     long_description="https://github.com/rcpch/digital-growth-charts/blob/master/README.md",
     # long_description_content_type='text/markdown',
@@ -61,7 +61,7 @@ setup(
     # },
     project_urls={  # Optional
         'Bug Reports': 'https://github.com/rcpch/digital-growth-charts/issues',
-        'API management:' 'https://dev.rcpch.ac.uk',
+        'API management': 'https://dev.rcpch.ac.uk',
         'Source': 'https://github.com/rcpch/digital-growth-charts',
     },
 )

--- a/schemas/calculation_schemas.py
+++ b/schemas/calculation_schemas.py
@@ -8,12 +8,12 @@ class CalculationRequestParameters(Schema):
     Defines the schema that the API expects to receive. This is compiled into the openAPI spec, and used for data validation
     """
 
-    birth_date = fields.Date(
+    birth_date = fields.DateTime(
         required=True,
-        description="Date of birth of the patient in YYYY-MM-DD ISO8601 format.")
-    observation_date = fields.Date(
+        description="Date of birth of the patient in `YYYY-MM-DDTHH:MM:SS` FHIR format.")
+    observation_date = fields.DateTime(
         required=True,
-        description="The date that the measurement was taken, in YYYY-MM-DD ISO8601 format.")
+        description="The date that the measurement was taken, in `YYYY-MM-DDTHH:MM:SS` FHIR format.")
     measurement_method = fields.String(
         required=True,
         enum=["height", "weight", "bmi", "ofc"],


### PR DESCRIPTION
Initially the API accepted YYYY-MM-DD date format only, which made sense to us, as time is irrelevant for centiles
However the DPCHR spec asks for Datetimes as YYYY-MM-DD'T'HH:MM:SS
This is consistent with ISO dates and RFC3339 as well as openAPI spec
We have implemented YYYY-MM-DD'T'HH:MM:SS as the expected date format

However, some API tools (Azure APIM dev portal, Postman) seem to mangle the Example request:
```
# original, in openapi.yml
birth_date: '2020-04-12T0:00:00'
gestation_days: 4
gestation_weeks: 40
measurement_method: height
observation_date: '2020-06-12T00:00:00'
observation_value: 60
sex: male

# azure 
{
    "birth_date": "2020-04-12T00:00:00.0000000",
    "gestation_days": 4,
    "gestation_weeks": 40,
    "measurement_method": "height",
    "observation_date": "2020-06-12T00:00:00.0000000",
    "observation_value": 60,
    "sex": "male"
}
```

So I have had to make it strip everything after the `.`
This seems to work.
I also improved error handling in the part of the requests that calls class Measurement. ValueErrors are caught and returned with a 422

Closes:
#135 
https://github.com/rcpch/api-management-platform/issues/9
#104 

Tests are incoming which will throw every kind of silly value at uk-who/calculation and make sure the right errors are raised. 
