### PR TITLE
Docker Start Script Fixes

### DIFF
--- a/s/start-docker
+++ b/s/start-docker
@@ -4,12 +4,18 @@
 app="rcpch-dgc-server"
 
 # usage: `s/start-docker`
-# run the container
-# will error if a container already exists
+# run the container in the foreground
+# will restart existing container if it exists
 # `docker container rm rcpch-dgc-server` to remove container
 # or use the `s/rebuild-docker` script
 
-docker run -it -p 5000:5000 \
-  --name=${app} \
-  --volume $PWD:/app \
-  ${app}
+
+if [ "$(docker ps -a --filter "name=${app}"  --format "{{.ID}}")" == "" ]; then
+  docker run -it -p 5000:5000 \
+    --name=${app} \
+    ${app}
+else
+  docker start ${app}
+  docker attach ${app}
+fi
+


### PR DESCRIPTION
1. Removes volume parameter from s/start-docker
2. Adds checking to s/start-docker to restart container if exists but stopped. Attaches to the running container to mirror the effect of the original script action.

Fixes issue #131 