### PR TITLE
Pin pydantic to v1

### DIFF
--- a/requirements/common-requirements.txt
+++ b/requirements/common-requirements.txt
@@ -4,7 +4,7 @@
 # third party dependencies
 fastapi[all]
 uvicorn[standard]
-pydantic
+pydantic == 1.*
 
 # rcpch dependencies
 # python package which does the centile and SDS calculations


### PR DESCRIPTION
Fixes an error at start up as the previously unpinned dependency was pulling in v2 which has several breaking changes.

> pydantic.errors.PydanticImportError: `BaseSettings` has been moved to the `pydantic-settings` package. See https://docs.pydantic.dev/2.6/migration/#basesettings-has-moved-to-pydantic-settings for more details.

There's already a PR to upgrade https://github.com/rcpch/digital-growth-charts-server/pull/197 but this just gets the `live` branch running locally again.