### PR TITLE
Further fixes to chart-cordinates endpoints

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -660,10 +660,17 @@
                         "title": "Centile"
                     },
                     "data": {
-                        "items": {
-                            "$ref": "#/components/schemas/Data"
-                        },
-                        "type": "array",
+                        "anyOf": [
+                            {
+                                "items": {
+                                    "$ref": "#/components/schemas/Data"
+                                },
+                                "type": "array"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
                         "title": "Data"
                     }
                 },
@@ -1716,10 +1723,17 @@
             "MeasurementMethod": {
                 "properties": {
                     "height": {
-                        "items": {
-                            "$ref": "#/components/schemas/Centile"
-                        },
-                        "type": "array",
+                        "anyOf": [
+                            {
+                                "items": {
+                                    "$ref": "#/components/schemas/Centile"
+                                },
+                                "type": "array"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
                         "title": "Height"
                     },
                     "weight": {
@@ -1766,9 +1780,6 @@
                     }
                 },
                 "type": "object",
-                "required": [
-                    "height"
-                ],
                 "title": "MeasurementMethod"
             },
             "MeasurementObject": {

--- a/schemas/response_schema_classes.py
+++ b/schemas/response_schema_classes.py
@@ -167,7 +167,7 @@ class Data(BaseModel):
 class Centile(BaseModel):
     sds: float
     centile: float
-    data: List[Data]
+    data: Optional[List[Data]]
 
 
 class MeasurementMethod(BaseModel):

--- a/tests/test_trisomy21.py
+++ b/tests/test_trisomy21.py
@@ -86,13 +86,20 @@ def test_trisomy_21_calculation_with_invalid_request():
     assert validation_errors["sex"]["msg"] == "Input should be 'male' or 'female'"
 
 
-@pytest.mark.skip(
-    reason="Complicated response to debug - needs further work. Note l key has changed from str to float."
-)
-def test_trisomy_21_chart_data_with_valid_request():
-    body = {
-        "measurement_method": "height",
-        "sex": "male",
+@pytest.mark.parametrize("input", [
+    { "measurement_method": "height", "sex": "male" },
+    { "measurement_method": "weight", "sex": "male" },
+    { "measurement_method": "ofc", "sex": "male" },
+    # TODO https://github.com/rcpch/digital-growth-charts-server/issues/217
+    # { "measurement_method": "bmi", "sex": "male" },
+    { "measurement_method": "height", "sex": "female" },
+    { "measurement_method": "weight", "sex": "female" },
+    { "measurement_method": "ofc", "sex": "female" }
+    # TODO https://github.com/rcpch/digital-growth-charts-server/issues/217
+    # { "measurement_method": "bmi", "sex": "female" }
+])
+def test_trisomy_21_chart_data_with_valid_request(input):
+    body = input | {
         "centile_format": "cole-nine-centiles",
     }
 
@@ -100,21 +107,7 @@ def test_trisomy_21_chart_data_with_valid_request():
 
     assert response.status_code == 200
 
-    # COMMENTED OUT FOR BRANCH 'dockerise' PENDING DECISION ON #166 (API Test Suite) (pacharanero, 2024-02-07 )
-    # load the known-correct response from file and create a hash of it
-    with open(r"tests/test_data/test_trisomy_21_male_height_valid.json", "r") as file:
-        chart_data_file = file.read()
-    # hash both JSON objects which should be identical
-    # hashing was the only efficient way to compare these two large (~500k) files
-    # it will be harder to debug any new difference (consider saving files to disk and compare)
-    # response_hash = hashlib.sha256(
-    #     json.dumps(
-    # ).hexdigest()
-    test_response = response.json()["centile_data"]
-    # chart_data_file_hash = hashlib.sha256(chart_data_file.encode("utf-8")).hexdigest()
-    chart_data_file = json.loads(chart_data_file)
-    # load the two JSON responses as Python Dicts so enable comparison (slow but more reliable)
-    assert test_response == chart_data_file
+    # TODO: Check the actual values returned. We do already validate it against the schema though.
 
 
 def test_trisomy_21_chart_data_with_invalid_request():

--- a/tests/test_turner.py
+++ b/tests/test_turner.py
@@ -84,13 +84,12 @@ def test_turner_calculation_with_invalid_request():
     assert validation_errors["sex"]["msg"] == "Input should be 'male' or 'female'"
 
 
-@pytest.mark.skip(
-    reason="chart coordinates are hashed - need a better way to test this. Unhashing takes too long."
-)
-def test_turner_chart_data_with_valid_request():
-    body = {
-        "measurement_method": "height",
-        "sex": "female",
+@pytest.mark.parametrize("input", [
+    # Turner data only exists for height in girls.
+    { "measurement_method": "height", "sex": "female" },
+])
+def test_turner_chart_data_with_valid_request(input):
+    body = input | {
         "centile_format": "cole-nine-centiles",
     }
 
@@ -98,17 +97,7 @@ def test_turner_chart_data_with_valid_request():
 
     assert response.status_code == 200
 
-    # COMMENTED OUT PENDING FIX NOT REQUIRING HASHING
-    # load the known-correct response from file and create a hash of it
-    # with open(r'tests/test_data/test_turner_female_height_valid.json', 'r') as file:
-    #    chart_data_file = file.read()
-    # hash both JSON objects which should be identical
-    # hashing was the only efficient way to compare these two large (~500k) files
-    # it will be harder to debug any new difference (consider saving files to disk and compare)
-    # response_hash = hashlib.sha256(json.dumps(response.json()['centile_data'], separators=(',', ':')).encode('utf-8')).hexdigest()
-    # chart_data_file_hash = hashlib.sha256(chart_data_file.encode('utf-8')).hexdigest()
-    # load the two JSON responses as Python Dicts so enable comparison (slow but more reliable)
-    # assert response_hash == chart_data_file_hash
+    # TODO: Check the actual values returned. We do already validate it against the schema though.
 
 
 @pytest.mark.skip(

--- a/tests/test_ukwho.py
+++ b/tests/test_ukwho.py
@@ -91,13 +91,18 @@ def test_ukwho_calculation_with_invalid_request():
     assert validation_errors["sex"]["msg"] == "Input should be 'male' or 'female'"
 
 
-@pytest.mark.skip(
-    reason="Complicated response to debug - needs further work. Note l key has changed from str to float."
-)
-def test_ukwho_chart_data_with_valid_request():
-    body = {
-        "measurement_method": "height",
-        "sex": "male",
+@pytest.mark.parametrize("input", [
+    { "measurement_method": "height", "sex": "male" },
+    { "measurement_method": "weight", "sex": "male" },
+    { "measurement_method": "ofc", "sex": "male" },
+    { "measurement_method": "bmi", "sex": "male" },
+    { "measurement_method": "height", "sex": "female" },
+    { "measurement_method": "weight", "sex": "female" },
+    { "measurement_method": "ofc", "sex": "female" },
+    { "measurement_method": "bmi", "sex": "female" }
+])
+def test_ukwho_chart_data_with_valid_request(input):
+    body = input | {
         "centile_format": "cole-nine-centiles",
         "is_sds": False,
     }
@@ -106,19 +111,7 @@ def test_ukwho_chart_data_with_valid_request():
 
     assert response.status_code == 200
 
-    # load the known-correct response from file and create a hash of it
-    # with open(r'tests/test_data/test_uk_who_male_height_valid.json', 'r') as file:
-    #     chart_data_file = file.read()
-    # hash both JSON objects which should be identical
-    # hashing was the only efficient way to compare these two large (~500k) files
-    # it will be harder to debug any new difference (consider saving files to disk and compare)
-    # response_hash = hashlib.sha256(json.dumps(response.json()['centile_data'], separators=(',', ':')).encode('utf-8')).hexdigest()
-    # chart_data_file_hash = hashlib.sha256(chart_data_file.encode('utf-8')).hexdigest()
-    # load the two JSON responses as Python Dicts so enable comparison (slow but more reliable)
-    # assert response_hash == chart_data_file_hash
-    # IMPORTANT: ONLY MALE, HEIGHT, UK-WHO is currently tested
-    # This test is a template which could be used for testing the
-    # other chart data responses (female/male and weight/bmi/ofc)
+    # TODO: Check the actual values returned. We do already validate it against the schema though.
 
 
 def test_ukwho_chart_data_with_invalid_request():


### PR DESCRIPTION
Fixes #216 

- Allow `null` in BMI data for preterm babies
- Unskip tests for chart coordinates endpoints
- Fix Open API spec JSON (including updates missed in #214)

There is still an outstanding failure here: https://github.com/rcpch/digital-growth-charts-server/issues/217