### PR TITLE
Cdc-lower-threshold-error

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 4.2.22
+current_version = 4.2.23
 tag = True
 commit = True
 

--- a/main.py
+++ b/main.py
@@ -13,7 +13,7 @@ from rcpchgrowth import chart_functions, constants
 from routers import trisomy_21, trisomy_21_aap, turners, uk_who, cdc, utilities
 
 
-version='4.2.22'  # this is set by bump version
+version='4.2.23'  # this is set by bump version
 
 # Declare the FastAPI app
 app = FastAPI(

--- a/openapi.json
+++ b/openapi.json
@@ -3,7 +3,7 @@
     "info": {
         "title": "RCPCH Digital Growth API",
         "description": "Returns SDS and centiles for child growth measurements using growth references. Currently provides calculations based on the UK-WHO, Turner's Syndrome and Trisomy-21 references.",
-        "version": "4.2.22"
+        "version": "4.2.23"
     },
     "paths": {
         "/uk-who/calculation": {

--- a/requirements/common-requirements.txt
+++ b/requirements/common-requirements.txt
@@ -8,4 +8,4 @@ pydantic == 2.*
 
 # rcpch dependencies
 # python package which does the centile and SDS calculations
-rcpchgrowth==4.2.5
+rcpchgrowth==4.2.6

--- a/tests/test_cdc.py
+++ b/tests/test_cdc.py
@@ -108,6 +108,46 @@ def test_cdc_chart_with_valid_request_for_outside_range_values(input):
 
     assert response.status_code == 422
 
+def test_cdc_chart_with_valid_request_for_preterm_baby_not_yet_term():
+
+    body = {
+        "measurement_method": "height",
+        "observation_value": 50,
+        "observation_date": "2021-11-12",
+        "birth_date": "2021-9-2",
+        "gestation_weeks": 29,
+        "gestation_days": 2,
+        "sex": "male"
+    }
+
+    
+
+    response = client.post("/cdc/calculation", json=body)
+
+    assert response.status_code == 422
+    assert response.json()["detail"][0]["msg"] == "CDC data does not exist below 40 weeks."
+
+
+def test_cdc_chart_with_valid_request_for_preterm_baby_corrected_age_now_term():
+
+    body = {
+        "measurement_method": "height",
+        "observation_value": 50,
+        "observation_date": "2021-11-20",
+        "birth_date": "2021-9-2",
+        "gestation_weeks": 29,
+        "gestation_days": 2,
+        "sex": "male"
+    }
+    
+    response = client.post("/cdc/calculation", json=body)
+
+    assert response.status_code == 200
+    assert response.json()["measurement_dates"]["chronological_decimal_age"]==0.216290212183436
+    assert response.json()["measurement_dates"]["corrected_decimal_age"]==0.010951403148528405
+    assert response.json()["measurement_dates"]["comments"]["lay_corrected_decimal_age_comment"]=="Because your child was born at 29+2 weeks gestation an adjustment has been made to take this into account."
+
+
 
 
 @pytest.mark.parametrize("input", [

--- a/tests/test_data/test_openapi.json
+++ b/tests/test_data/test_openapi.json
@@ -3,7 +3,7 @@
     "info": {
         "title": "RCPCH Digital Growth API",
         "description": "Returns SDS and centiles for child growth measurements using growth references. Currently provides calculations based on the UK-WHO, Turner's Syndrome and Trisomy-21 references.",
-        "version": "4.2.22"
+        "version": "4.2.23"
     },
     "paths": {
         "/uk-who/calculation": {


### PR DESCRIPTION
### Overview

Fixes lack of meaningful error if preterm data requested for CDC

CDC has no preterm data so if a baby < 40 weeks is requested, this will be rejected now with a meaningful error

Note:
If a baby's corrected age is > 40 weeks, then a calculation will be performed and returned.

If a baby's corrected age is < 40 weeks, the python package will actually return calculations for the chronological age, but an error in the `observation_value_error` field for corrected age. In the API though, all calls for preterm babies who have yet to reach 40 weeks will be rejected as chronological age alone here is not useful and at worst misleading from a clinical point of view.

There is a small problem here in that babies are technically term from 37 weeks, and in the UK we correct gestation for all of these. This is not the case in the US though. This means the API would reject term babies where the gestation is provided and there are still only a couple of weeks old as they would be less than 40 weeks. To get round this there will need to be a separate fix in the python package to take this into account and and separate update to the server.


