### PR TITLE
even better invalid message for child out of range including age and sex

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 4.3.4
+current_version = 4.3.5
 tag = True
 commit = True
 

--- a/main.py
+++ b/main.py
@@ -13,7 +13,7 @@ from rcpchgrowth import chart_functions, constants
 from routers import trisomy_21, trisomy_21_aap, turners, uk_who, cdc, who, utilities
 
 
-version='4.3.4'  # this is set by bump version
+version='4.3.5'  # this is set by bump version
 
 # Declare the FastAPI app
 app = FastAPI(

--- a/openapi.json
+++ b/openapi.json
@@ -3,7 +3,7 @@
     "info": {
         "title": "RCPCH Digital Growth API",
         "description": "Returns SDS and centiles for child growth measurements using growth references. Currently provides calculations based on the UK-WHO, Turner's Syndrome and Trisomy-21 references.",
-        "version": "4.3.4"
+        "version": "4.3.5"
     },
     "paths": {
         "/uk-who/calculation": {

--- a/routers/validate_observation_value.py
+++ b/routers/validate_observation_value.py
@@ -1,4 +1,4 @@
-from rcpchgrowth import corrected_decimal_age, MINIMUM_BMI_ERROR_SDS, MAXIMUM_BMI_ERROR_SDS, MINIMUM_HEIGHT_WEIGHT_OFC_ERROR_SDS, MAXIMUM_HEIGHT_WEIGHT_OFC_ERROR_SDS, sds_for_measurement, TWENTY_FIVE_WEEKS_GESTATION, TWENTY_THREE_WEEKS_GESTATION
+from rcpchgrowth import corrected_decimal_age, MINIMUM_BMI_ERROR_SDS, MAXIMUM_BMI_ERROR_SDS, MINIMUM_HEIGHT_WEIGHT_OFC_ERROR_SDS, MAXIMUM_HEIGHT_WEIGHT_OFC_ERROR_SDS, sds_for_measurement, chronological_calendar_age
 
 def validate_observation_value(reference, values):
     """
@@ -25,8 +25,20 @@ def validate_observation_value(reference, values):
     except LookupError as e:
         print(e)
         raise ValueError(e)
+    
+    try:
+        calendar_age = chronological_calendar_age(
+            birth_date=birth_date,
+            observation_date=observation_date,
+        )
+    except ValueError as e:
+        print(e)
+        raise ValueError(e)
 
+    units = "cm" if measurement_method in ["height", "ofc"] else "kg"
+    boy_girl = "boy" if sex == "male" else "girl"
     if measurement_method == "bmi":
+        units = "kg/m²"
         if calculated_sds < MINIMUM_BMI_ERROR_SDS:
             raise ValueError("Body mass index cannot be less than -15 SD.")
         if calculated_sds > MAXIMUM_BMI_ERROR_SDS:
@@ -35,8 +47,8 @@ def validate_observation_value(reference, values):
         if measurement_method == "ofc":
             measurement_method = "Head circumference"
         if calculated_sds < MINIMUM_HEIGHT_WEIGHT_OFC_ERROR_SDS:
-            raise ValueError(f"{measurement_method} cannot be less than -8 SD.")
+            raise ValueError(f"A {measurement_method} of {observation_value} {units} in a {boy_girl} of {calendar_age} is less than -8 SD. Please recheck the measurement and date of birth.")
         if calculated_sds > MAXIMUM_HEIGHT_WEIGHT_OFC_ERROR_SDS:
-            raise ValueError(f"{measurement_method} cannot be more than +8 SD.")
+            raise ValueError(f"A {measurement_method} of {observation_value} {units} in a {boy_girl} of {calendar_age} is more than +8 SD. Please recheck the measurement and date of birth.")
 
     return values

--- a/tests/test_data/test_openapi.json
+++ b/tests/test_data/test_openapi.json
@@ -3,7 +3,7 @@
     "info": {
         "title": "RCPCH Digital Growth API",
         "description": "Returns SDS and centiles for child growth measurements using growth references. Currently provides calculations based on the UK-WHO, Turner's Syndrome and Trisomy-21 references.",
-        "version": "4.3.4"
+        "version": "4.3.5"
     },
     "paths": {
         "/uk-who/calculation": {


### PR DESCRIPTION
### Overview

So really a misremembering on my part.
Errors on out of bounds measurements are raised both in the package as well as in the server.

The error messages for out of bounds measurements coming from the python package are picked up by the charting component in the tool tips, but measurements that out of bounds would not make it out of the API as there is error handling here also for the extreme values which I had forgotten about. These are found in the fairly new `validate_observation_value.py`. This was introduced when the SD validation were introduced earlier this year.

So this PR provides better context to the error response for users and includes the age and sex of the child as well as the measurement supplied with a reminder to check all these parameters
