### PR TITLE
No need to inject prout header on all routes

### DIFF
--- a/main.py
+++ b/main.py
@@ -55,7 +55,7 @@ github_sha = os.getenv('GITHUB_SHA')
 async def include_github_sha_for_prout(request, call_next):
     response = await call_next(request)
     
-    if github_sha:
+    if request.url.path == '/' and github_sha:
         response.headers["X-Git-Revision"] = github_sha
 
     return response


### PR DESCRIPTION
Follow up to #258 - we only need the prout header with the git revision on the page prout will check (our main page serving the OpenAPI spec).

Remove it from the other endpoints as these are designed to be consumed by `curl` when testing and it's just confusion and a few extra bytes.