### PR TITLE
Pin GitHub actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,23 @@
+# Dependabot configuration.
+#
+# - Keeps GitHub Actions up to date.
+# - Actions are pinned to commit SHAs in workflows; Dependabot still
+#   recognises and updates SHA-pinned uses, preserving the trailing
+#   "# vX.Y.Z" version comment when it opens an update PR.
+# - The cooldown.default-days value gives 7 days between an upstream
+#   release and Dependabot raising a PR for it. This reduces exposure to
+#   compromised releases that get yanked or revoked shortly after publication
+#   (a common supply-chain attack pattern), while still keeping us current.
+#
+# Docs: https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+    commit-message:
+      prefix: "ci"
+      include: "scope"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,10 +15,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 'Checkout GitHub Action'
-        uses: actions/checkout@main
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # main
       
       - name: 'Login via Azure CLI'
-        uses: azure/login@v2
+        uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 # v2
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -11,7 +11,7 @@ jobs:
     
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Run PR check script
         run: s/pr-check


### PR DESCRIPTION
Pin third-party GitHub Actions to immutable commit SHAs (with a trailing version-tag comment for human readability) to mitigate supply-chain attacks via tag re-pointing. Add a Dependabot config that maintains the github-actions ecosystem with a 7-day cooldown so we don't adopt brand-new releases until any yanks/revocations have surfaced.

Each workflow has a header comment explaining the SHA-pinning convention and linking to the GitHub security-hardening docs and the mheap/pin-github-action tool.

Following process from @pacharanero in https://github.com/rcpch/rcpchgrowth-python/pull/87.