### PR TITLE
Use TestCase assertions for better diffs

### DIFF
--- a/tests/test_cdc.py
+++ b/tests/test_cdc.py
@@ -5,6 +5,7 @@ Tests for the CDC endpoints
 # standard imports
 import json
 import hashlib
+from unittest import TestCase
 
 # third party imports
 from fastapi.testclient import TestClient
@@ -41,13 +42,12 @@ def test_cdc_calculation_with_valid_request():
     # load the known-correct response from file
     with open(r"tests/test_data/test_cdc_calculation_valid.json", "r") as file:
         calculation_file = file.read()
+    
     # load the two JSON responses as Python Dicts so enable comparison (slow but more reliable)
+    expected = json.loads(calculation_file)
+    actual = response.json()
 
-    calculation_json = json.loads(calculation_file)
-
-    print(f"!! {response.json()["measurement_calculated_values"]["corrected_centile"]} == {calculation_json["measurement_calculated_values"]["corrected_centile"]} !!")
-
-    assert response.json() == calculation_json
+    TestCase().assertDictEqual(expected, actual)
 
 
 def test_cdc_calculation_with_invalid_request():
@@ -220,8 +220,12 @@ def test_cdc_fictional_child_data_with_valid_request():
         r"tests/test_data/test_cdc_fictional_child_data_valid.json", "r"
     ) as file:
         fictional_child_data_file = file.read()
+    
     # load the two JSON responses as Python Dicts so enable comparison (slow but more reliable)
-    assert response.json() == json.loads(fictional_child_data_file)
+    expected = json.loads(fictional_child_data_file)
+    actual = response.json()
+
+    TestCase().assertListEqual(expected, actual)
 
 
 def test_cdc_bulk_calculation_all_valid():

--- a/tests/test_trisomy21.py
+++ b/tests/test_trisomy21.py
@@ -5,6 +5,7 @@ Tests for the Trisomy 21 endpoints
 # standard imports
 import json
 import hashlib
+from unittest import TestCase
 
 # third party imports
 from fastapi.testclient import TestClient
@@ -36,9 +37,11 @@ def test_trisomy_21_calculation_with_valid_request():
 
     assert response.status_code == 200
 
-    # COMMENTED OUT FOR BRANCH 'dockerise' PENDING DECISION ON #166 (API Test Suite) (pacharanero, 2024-02-07 )
     # load the two JSON responses as Python Dicts so enable comparison (slow but more reliable)
-    assert response.json() == json.loads(calculation_file)
+    expected = json.loads(calculation_file)
+    actual = response.json()
+
+    TestCase().assertDictEqual(expected, actual)
 
 
 def test_trisomy_21_calculation_with_invalid_request():

--- a/tests/test_trisomy21_aap.py
+++ b/tests/test_trisomy21_aap.py
@@ -5,6 +5,7 @@ Tests for the Trisomy 21 endpoints
 # standard imports
 import json
 import hashlib
+from unittest import TestCase
 
 # third party imports
 from fastapi.testclient import TestClient
@@ -36,9 +37,11 @@ def test_trisomy_21_aap_calculation_with_valid_request():
 
     assert response.status_code == 200
 
-    # COMMENTED OUT FOR BRANCH 'dockerise' PENDING DECISION ON #166 (API Test Suite) (pacharanero, 2024-02-07 )
     # load the two JSON responses as Python Dicts so enable comparison (slow but more reliable)
-    assert response.json() == json.loads(calculation_file)
+    expected = json.loads(calculation_file)
+    actual = response.json()
+
+    TestCase().assertDictEqual(expected, actual)
 
 
 def test_trisomy_21_aap_calculation_with_invalid_request():
@@ -169,8 +172,12 @@ def test_trisomy_21_aap_fictional_child_data_with_valid_request():
         r"tests/test_data/test_trisomy_21_aap_fictional_child_data_valid.json", "r"
     ) as file:
         fictional_child_data_file = file.read()
+    
     # load the two JSON responses as Python Dicts so enable comparison (slow but more reliable)
-    assert response.json() == json.loads(fictional_child_data_file)
+    expected = json.loads(fictional_child_data_file)
+    actual = response.json()
+
+    TestCase().assertListEqual(expected, actual)
 
 
 def test_trisomy_21_aap_bulk_calculation_all_valid():

--- a/tests/test_turner.py
+++ b/tests/test_turner.py
@@ -5,6 +5,7 @@ Tests for the Turner endpoints
 # standard imports
 import json
 import hashlib
+from unittest import TestCase
 
 # third party imports
 from fastapi.testclient import TestClient
@@ -35,8 +36,12 @@ def test_turner_calculation_with_valid_request():
     # load the known-correct response from file
     with open(r"tests/test_data/test_turner_calculation_valid.json", "r") as file:
         calculation_file = file.read()
+    
     # load the two JSON responses as Python Dicts so enable comparison (slow but more reliable)
-    assert response.json() == json.loads(calculation_file)
+    expected = json.loads(calculation_file)
+    actual = response.json()
+
+    TestCase().assertDictEqual(expected, actual)
 
 
 def test_turner_calculation_with_invalid_request():
@@ -161,8 +166,12 @@ def test_turner_fictional_child_data_with_valid_request():
         r"tests/test_data/test_turner_fictional_child_data_valid.json", "r"
     ) as file:
         fictional_child_data_file = file.read()
+    
     # load the two JSON responses as Python Dicts so enable comparison (slow but more reliable)
-    assert response.json() == json.loads(fictional_child_data_file)
+    expected = json.loads(fictional_child_data_file)
+    actual = response.json()
+
+    TestCase().assertListEqual(expected, actual)
 
 
 def test_turner_fictional_child_data_with_invalid_request():

--- a/tests/test_ukwho.py
+++ b/tests/test_ukwho.py
@@ -5,6 +5,7 @@ Tests for the UK-WHO endpoints
 # standard imports
 import json
 import hashlib
+from unittest import TestCase
 
 # third party imports
 from fastapi.testclient import TestClient
@@ -41,8 +42,12 @@ def test_ukwho_calculation_with_valid_request():
     # load the known-correct response from file
     with open(r"tests/test_data/test_ukwho_calculation_valid.json", "r") as file:
         calculation_file = file.read()
+    
     # load the two JSON responses as Python Dicts so enable comparison (slow but more reliable)
-    assert response.json() == json.loads(calculation_file)
+    expected = json.loads(calculation_file)
+    actual = response.json()
+
+    TestCase().assertDictEqual(expected, actual)
 
 
 def test_ukwho_calculation_with_invalid_request():
@@ -178,8 +183,12 @@ def test_ukwho_fictional_child_data_with_valid_request():
         r"tests/test_data/test_ukwho_fictional_child_data_valid.json", "r"
     ) as file:
         fictional_child_data_file = file.read()
+    
     # load the two JSON responses as Python Dicts so enable comparison (slow but more reliable)
-    assert response.json() == json.loads(fictional_child_data_file)
+    expected = json.loads(fictional_child_data_file)
+    actual = response.json()
+
+    TestCase().assertListEqual(expected, actual)
 
 
 def test_ukwho_bulk_calculation_all_valid():

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -38,8 +38,6 @@ def test_midparental_height_ukwho_with_valid_request():
     assert round(float(file_data["mid_parental_height_upper_value"]),1)==float(response.json()["mid_parental_height_upper_value"]), f"mid_parental_height_upper_value for uk-who should be {round(float(file_data['mid_parental_height_upper_value']),1)} but returned {float(response.json()['mid_parental_height_upper_value'])}"
     assert round(float(file_data["mid_parental_height_lower_value"]),1)==float(response.json()["mid_parental_height_lower_value"]), f"mid_parental_height_lower_value for uk-who should be {round(float(file_data['mid_parental_height_lower_value']),1)} but returned {float(response.json()['mid_parental_height_lower_value'])}"
 
-    # load the two JSON responses as Python Dicts so enable comparison (slow but more reliable)
-    # assert response.json() == json.loads(calculation_file)
 
 def test_midparental_height_cdc_with_valid_request():
     """

--- a/tests/test_who.py
+++ b/tests/test_who.py
@@ -5,6 +5,7 @@ Tests for the UK-WHO endpoints
 # standard imports
 import json
 import hashlib
+from unittest import TestCase
 
 # third party imports
 from fastapi.testclient import TestClient
@@ -41,8 +42,12 @@ def test_who_calculation_with_valid_request():
     # load the known-correct response from file
     with open(r"tests/test_data/test_who_calculation_valid.json", "r") as file:
         calculation_file = file.read()
+    
     # load the two JSON responses as Python Dicts so enable comparison (slow but more reliable)
-    assert response.json() == json.loads(calculation_file)
+    expected = json.loads(calculation_file)
+    actual = response.json()
+
+    TestCase().assertDictEqual(expected, actual)
 
 
 def test_who_calculation_with_invalid_request():
@@ -170,8 +175,12 @@ def test_who_fictional_child_data_with_valid_request():
         r"tests/test_data/test_who_fictional_child_data_valid.json", "r"
     ) as file:
         fictional_child_data_file = file.read()
+    
     # load the two JSON responses as Python Dicts so enable comparison (slow but more reliable)
-    assert response.json() == json.loads(fictional_child_data_file)
+    expected = json.loads(fictional_child_data_file)
+    actual = response.json()
+
+    TestCase().assertListEqual(expected, actual)
 
 
 def test_who_fictional_child_data_with_invalid_request():


### PR DESCRIPTION
The test failures from upgrading to rcpchgrowth-python 4.5.0 (https://github.com/rcpch/digital-growth-charts-server/pull/275) are very hard to debug. These assertions print out more reasonable diffs:

```
E       AssertionError: {'bir[1163 chars]0.01671356056807963, 'corrected_centile': 49.3[3079 chars]one}} != {'bir[1163 chars]0.01669429447792642, 'corrected_centile': 49.3[3073 chars]one}}
E       Diff is 25704 characters long. Set self.maxDiff to None to see it.
```

I thought it cleaner to do this change separately and then rebase the other PR.