### PR TITLE
fix: grammatically incongruous error message for a measurement on the day of birth

### DIFF
--- a/routers/validate_observation_value.py
+++ b/routers/validate_observation_value.py
@@ -71,6 +71,14 @@ def validate_observation_value(reference, values, observation_values=None):
 
     units = "cm" if measurement_method in ["height", "ofc"] else "kg"
     boy_girl = "boy" if sex == "male" else "girl"
+    # chronological_calendar_age() returns the standalone label "Birth date"
+    # for an observation taken on the day of birth (age zero), rather than a
+    # noun phrase such as "3 years, 2 months" - it is not designed to be
+    # embedded mid-sentence. Interpolating it directly into "... in a {boy_girl}
+    # of {calendar_age} ..." therefore produced the grammatically incongruous
+    # "in a boy of Birth date is more than +8 SD ...". Build a phrase that
+    # reads correctly in both cases instead of interpolating the raw label.
+    age_phrase = "born today" if calendar_age == "Birth date" else f"of {calendar_age}"
     if measurement_method == "bmi":
         units = "kg/m²"
         if calculated_sds < MINIMUM_BMI_ERROR_SDS:
@@ -81,8 +89,8 @@ def validate_observation_value(reference, values, observation_values=None):
         if measurement_method == "ofc":
             measurement_method = "Head circumference"
         if calculated_sds < MINIMUM_HEIGHT_WEIGHT_OFC_ERROR_SDS:
-            raise ValueError(f"A {measurement_method} of {observation_value} {units} in a {boy_girl} of {calendar_age} is less than -8 SD. Please recheck the measurement and date of birth.")
+            raise ValueError(f"A {measurement_method} of {observation_value} {units} in a {boy_girl} {age_phrase} is less than -8 SD. Please recheck the measurement and date of birth.")
         if calculated_sds > MAXIMUM_HEIGHT_WEIGHT_OFC_ERROR_SDS:
-            raise ValueError(f"A {measurement_method} of {observation_value} {units} in a {boy_girl} of {calendar_age} is more than +8 SD. Please recheck the measurement and date of birth.")
+            raise ValueError(f"A {measurement_method} of {observation_value} {units} in a {boy_girl} {age_phrase} is more than +8 SD. Please recheck the measurement and date of birth.")
 
     return values

--- a/tests/test_birth_date_error_message_grammar.py
+++ b/tests/test_birth_date_error_message_grammar.py
@@ -1,0 +1,83 @@
+"""
+Regression test for an incongruous error-message sentence.
+
+`chronological_calendar_age()` returns the standalone label "Birth date"
+for an observation taken on the day of birth, rather than a noun phrase
+such as "3 years, 2 months". validate_observation_value.py used to
+interpolate that label directly into a sentence built for a noun phrase,
+producing:
+
+    "A height of 100.0 cm in a boy of Birth date is more than +8 SD.
+     Please recheck the measurement and date of birth."
+
+This asserts the corrected phrasing for both the +8 SD and -8 SD paths, on
+the day of birth specifically (age zero, the only case that triggers the
+"Birth date" label), and that the ordinary non-zero-age phrasing is
+unaffected.
+"""
+
+from fastapi.testclient import TestClient
+
+from main import app
+
+client = TestClient(app)
+
+
+def test_extreme_high_measurement_on_day_of_birth_has_grammatical_message():
+    response = client.post(
+        "/uk-who/calculation",
+        json={
+            "birth_date": "2024-01-01",
+            "observation_date": "2024-01-01",
+            "observation_value": 100.0,
+            "sex": "male",
+            "measurement_method": "height",
+        },
+    )
+    assert response.status_code == 422
+    msg = response.json()["detail"][0]["msg"]
+    assert "born today" in msg
+    assert "of Birth date" not in msg
+    assert msg == (
+        "A height of 100.0 cm in a boy born today is more than +8 SD. "
+        "Please recheck the measurement and date of birth."
+    )
+
+
+def test_extreme_low_measurement_on_day_of_birth_has_grammatical_message():
+    response = client.post(
+        "/uk-who/calculation",
+        json={
+            "birth_date": "2024-01-01",
+            "observation_date": "2024-01-01",
+            "observation_value": 5.0,
+            "sex": "female",
+            "measurement_method": "height",
+        },
+    )
+    assert response.status_code == 422
+    msg = response.json()["detail"][0]["msg"]
+    assert "born today" in msg
+    assert "of Birth date" not in msg
+    assert msg == (
+        "A height of 5.0 cm in a girl born today is less than -8 SD. "
+        "Please recheck the measurement and date of birth."
+    )
+
+
+def test_extreme_measurement_at_a_non_zero_age_is_unaffected():
+    response = client.post(
+        "/uk-who/calculation",
+        json={
+            "birth_date": "2020-01-01",
+            "observation_date": "2024-01-01",
+            "observation_value": 300.0,
+            "sex": "male",
+            "measurement_method": "height",
+        },
+    )
+    assert response.status_code == 422
+    msg = response.json()["detail"][0]["msg"]
+    assert "born today" not in msg
+    assert " of " in msg
+    assert "4 years" in msg


### PR DESCRIPTION
## Summary

Fixes an ungrammatical validation error message when an out-of-range measurement is recorded on the child's day of birth.

## Before

```
A height of 100.0 cm in a boy of Birth date is more than +8 SD. Please recheck the measurement and date of birth.
```

## After

```
A height of 100.0 cm in a boy born today is more than +8 SD. Please recheck the measurement and date of birth.
```

## Root cause

1. **Is this originating from Python or the API?** Both, in different ways. `rcpchgrowth`'s `chronological_calendar_age()` correctly returns the standalone label `"Birth date"` for age zero - that's a sensible answer if you're displaying "Age: Birth date" as a label, and I don't think it should change. The bug is entirely on this side: `validate_observation_value.py` interpolates that label directly into a sentence built for a noun phrase (`"... in a boy of {calendar_age} is more than +8 SD ..."`), and `"of Birth date"` isn't a grammatical completion of that sentence regardless of capitalisation.

2. No `rcpchgrowth` change needed. The fix is contained entirely in this repo: build the age phrase explicitly (`"born today"` vs `"of {calendar_age}"`) rather than always interpolating the raw label.

## Scope

Deliberately small and based on `live` rather than the other in-flight branch, so it's easy to review and rebase independently of the larger provenance/error-handling work in #280.

## Testing

New `tests/test_birth_date_error_message_grammar.py`: exact message text for both the +8 SD and -8 SD paths on the day of birth, and confirms the ordinary non-zero-age phrasing is unaffected.

Full suite, built image, run for real (not just diffed): `143 passed, 1 skipped` - unchanged from `live` before this change.