### PR TITLE
test: mark APIM OpenAPI synchronization

### DIFF
--- a/main.py
+++ b/main.py
@@ -89,7 +89,11 @@ app.openapi = custom_openapi
 
 
 # Include the root endpoint (so it is _described_ in the APIspec).
-@app.get("/", tags=["openapi3"])
+@app.get(
+    "/",
+    tags=["openapi3"],
+    summary="API specification - APIM sync E2E test 2026-09-03",
+)
 def root():
     """
     # API spec endpoint

--- a/openapi.json
+++ b/openapi.json
@@ -1293,7 +1293,7 @@
                 "tags": [
                     "openapi3"
                 ],
-                "summary": "Root",
+                "summary": "API specification - APIM sync E2E test 2026-09-03",
                 "description": "# API spec endpoint\n* The root `/` API endpoint returns the openAPI3 specification in JSON format\n* This spec is also available in the root of the server code repository",
                 "operationId": "root__get",
                 "responses": {


### PR DESCRIPTION
Adds a temporary, dated summary to the root OpenAPI operation so we can verify that the live deployment updates APIM revision 2. The operation ID and all API behaviour remain unchanged.

This marker must be reverted after it has been observed in APIM.

## Verification

- `s/pr-check`: 140 passed, 1 skipped
- `uvx --from openapi-spec-validator==0.9.0 openapi-spec-validator openapi.json`: OK
- Confirmed 26 paths and unchanged `root__get` operation ID