### PR TITLE
test: remove APIM synchronization marker

### DIFF
--- a/main.py
+++ b/main.py
@@ -89,11 +89,7 @@ app.openapi = custom_openapi
 
 
 # Include the root endpoint (so it is _described_ in the APIspec).
-@app.get(
-    "/",
-    tags=["openapi3"],
-    summary="API specification - APIM sync E2E test 2026-09-03",
-)
+@app.get("/", tags=["openapi3"])
 def root():
     """
     # API spec endpoint

--- a/openapi.json
+++ b/openapi.json
@@ -1293,7 +1293,7 @@
                 "tags": [
                     "openapi3"
                 ],
-                "summary": "API specification - APIM sync E2E test 2026-09-03",
+                "summary": "Root",
                 "description": "# API spec endpoint\n* The root `/` API endpoint returns the openAPI3 specification in JSON format\n* This spec is also available in the root of the server code repository",
                 "operationId": "root__get",
                 "responses": {


### PR DESCRIPTION
Removes the temporary root-operation summary added by #286 now that it has been observed in APIM revision 2. This restores the generated `Root` summary without changing the operation ID or API behavior.

After this deploys, APIM revision 2 should no longer show `API specification - APIM sync E2E test 2026-09-03`.

## Verification

- `s/pr-check`: 140 passed, 1 skipped
- `uvx --from openapi-spec-validator==0.9.0 openapi-spec-validator openapi.json`: OK
- Confirmed 26 paths and unchanged `root__get` operation ID